### PR TITLE
verify if metadata repository addresses netty-logging issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,9 @@
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>--no-server</buildArg>
               </buildArgs>
+              <metadataRepository>
+                <enabled>true</enabled>
+              </metadataRepository>
             </configuration>
           </plugin>
         </plugins>

--- a/src/main/resources/META-INF/native-image/native-image.properties
+++ b/src/main/resources/META-INF/native-image/native-image.properties
@@ -1,7 +1,7 @@
 # [START java_native_image_logging_config_slf4j]
-Args=\
-  --initialize-at-build-time=\
-  org.slf4j.jul.JDK14LoggerAdapter,\
-  org.slf4j.LoggerFactory
+#Args=\
+#  --initialize-at-build-time=\
+#  org.slf4j.jul.JDK14LoggerAdapter,\
+#  org.slf4j.LoggerFactory
 
 # [END java_native_image_logging_config_slf4j]


### PR DESCRIPTION
Adding the following configuration to the native-maven-plugin configurations results in a successful build. The downside of using the metadata repository is that, we end up seeing a lot of warnings during the native image build:
```
Warning: Could not resolve com.barchart.udt.LingerUDT for reflection configuration. Reason: java.lang.ClassNotFoundException: com.barchart.udt.LingerUDT.
Warning: Could not resolve com.github.luben.zstd.ZstdCompressCtx for reflection configuration. Reason: java.lang.ClassNotFoundException: com.github.luben.zstd.ZstdCompressCtx.
Warning: Could not resolve io.netty.handler.ssl.OpenSslClientSessionCache for reflection configuration. Reason: java.lang.NoClassDefFoundError: io/netty/internal/tcnative/SSLSessionCache.
Warning: Could not resolve io.netty.handler.ssl.ReferenceCountedOpenSslClientContext$ExtendedTrustManagerVerifyCallback for reflection configuration. Reason: java.lang.NoClassDefFoundError: io/netty/internal/tcnative/CertificateVerifier.
Warning: Could not resolve io.netty.handler.ssl.ReferenceCountedOpenSslServerContext$ExtendedTrustManagerVerifyCallback for reflection configuration. Reason: java.lang.NoClassDefFoundError: io/netty/internal/tcnative/CertificateVerifier.
Warning: Could not resolve io.netty.handler.ssl.ReferenceCountedOpenSslServerContext$OpenSslServerCertificateCallback for reflection configuration. Reason: java.lang.NoClassDefFoundError: io/netty/internal/tcnative/CertificateCallback.
Warning: Could not resolve org.conscrypt.ConscryptEngine for reflection configuration. Reason: java.lang.ClassNotFoundException: org.conscrypt.ConscryptEngine.
Warning: Could not resolve org.conscrypt.ConscryptEngine for reflection configuration. Reason: java.lang.ClassNotFoundException: org.conscrypt.ConscryptEngine.
Warning: Could not resolve org.conscrypt.ConscryptEngine for reflection configuration. Reason: java.lang.ClassNotFoundException: org.conscrypt.ConscryptEngine.
Warning: Could not resolve ch.qos.logback.classic.encoder.PatternLayoutEncoder for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.encoder.PatternLayoutEncoder.
Warning: Could not resolve ch.qos.logback.classic.encoder.PatternLayoutEncoder for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.encoder.PatternLayoutEncoder.
Warning: Could not resolve ch.qos.logback.classic.encoder.PatternLayoutEncoder for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.encoder.PatternLayoutEncoder.
Warning: Could not resolve ch.qos.logback.classic.encoder.PatternLayoutEncoder for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.encoder.PatternLayoutEncoder.
Warning: Could not resolve ch.qos.logback.classic.encoder.PatternLayoutEncoder for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.encoder.PatternLayoutEncoder.
Warning: Could not resolve ch.qos.logback.classic.encoder.PatternLayoutEncoder for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.encoder.PatternLayoutEncoder.
Warning: Could not resolve ch.qos.logback.classic.encoder.PatternLayoutEncoder for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.encoder.PatternLayoutEncoder.
Warning: Could not resolve ch.qos.logback.classic.encoder.PatternLayoutEncoder for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.encoder.PatternLayoutEncoder.
Warning: Could not resolve ch.qos.logback.classic.encoder.PatternLayoutEncoder for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.encoder.PatternLayoutEncoder.
Warning: Could not resolve ch.qos.logback.classic.encoder.PatternLayoutEncoder for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.encoder.PatternLayoutEncoder.
Warning: Could not resolve ch.qos.logback.classic.encoder.PatternLayoutEncoder for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.encoder.PatternLayoutEncoder.
Warning: Could not resolve ch.qos.logback.classic.encoder.PatternLayoutEncoder for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.encoder.PatternLayoutEncoder.
Warning: Could not resolve ch.qos.logback.classic.encoder.PatternLayoutEncoder for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.encoder.PatternLayoutEncoder.
Warning: Could not resolve ch.qos.logback.classic.pattern.DateConverter for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.pattern.DateConverter.
Warning: Could not resolve ch.qos.logback.classic.pattern.LevelConverter for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.pattern.LevelConverter.
Warning: Could not resolve ch.qos.logback.classic.pattern.LineSeparatorConverter for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.pattern.LineSeparatorConverter.
Warning: Could not resolve ch.qos.logback.classic.pattern.LoggerConverter for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.pattern.LoggerConverter.
Warning: Could not resolve ch.qos.logback.classic.pattern.MessageConverter for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.pattern.MessageConverter.
Warning: Could not resolve ch.qos.logback.classic.pattern.ThreadConverter for reflection configuration. Reason: java.lang.ClassNotFoundException: ch.qos.logback.classic.pattern.ThreadConverter.

```